### PR TITLE
:bug: Fix multiline overwrite output

### DIFF
--- a/models/chatglm/__init__.py
+++ b/models/chatglm/__init__.py
@@ -33,8 +33,10 @@ class ChatGLMMdoel(LLMModel):
         history = []
         while True:
             text = input("用户输入:")
+            last_response = ""
             for response, history in self.model.stream_chat(self.tokenizer, text, history=history):
-                print(response, end='\r')
+                print(response[len(last_response):], end='')
+                last_response = response
             print(flush=True)
     
     def run_web_demo(self, input_text, history=[]):


### PR DESCRIPTION
A bad output:
<img width="962" alt="image" src="https://github.com/Jittor/JittorLLMs/assets/11549103/df690995-d130-401d-8fa6-3e9bb11a781e">
